### PR TITLE
when dataType is text, convert to string

### DIFF
--- a/lib/urllib.js
+++ b/lib/urllib.js
@@ -107,7 +107,7 @@ exports.TIMEOUT = 5000;
  *       If you use this, callback's data should be null.
  *       We will just `pipe(ws, {end: true})`.
  *   - {String} [method]: optional, could be GET | POST | DELETE | PUT, default is GET
- *   - {String} [dataType]: optional, `text` or `json`, default is text
+ *   - {String} [dataType]: optional, `text` or `json`, default is buffer
  *   - {Object} [headers]: optional, request headers
  *   - {Number} [timeout]: request timeout(in milliseconds), default is `exports.TIMEOUT`
  *   - {Agent} [agent]: optional, http agent. Set `false` if you does not use agent.
@@ -339,16 +339,20 @@ function *request(url, args) {
     }
 
     // if response body not decode, dont touch it
-    if (!encoding && args.dataType === 'json') {
-      try {
-        data = JSON.parse(data);
-      } catch (err) {
-        err.message += ' (' + method + ' ' + url + ')';
-        err.name = 'JSONResponseFormatError';
-        err.status = res.statusCode;
-        err.headers = res.headers;
-        err.data = data;
-        throw err;
+    if (!encoding && args.dataType) {
+      if (args.dataType === 'json') {
+        try {
+          data = JSON.parse(data);
+        } catch (err) {
+          err.message += ' (' + method + ' ' + url + ')';
+          err.name = 'JSONResponseFormatError';
+          err.status = res.statusCode;
+          err.headers = res.headers;
+          err.data = data;
+          throw err;
+        }
+      } else if (args.dataType === 'text') {
+        data = data.toString();
       }
     }
   }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -329,6 +329,15 @@ describe('index.test.js', function () {
     });
   });
 
+  describe('options.dataType = text', function () {
+    it('should got json', function *() {
+      var result = yield *urllib.request(host + '/json', {dataType: 'text'});
+      result.should.have.keys('data', 'status', 'headers');
+      result.status.should.equal(200);
+      result.data.should.eql(JSON.stringify({foo: 'bar'}));
+    });
+  });
+
   describe('options.timeout', function () {
     it('should throw ConnectionTimeoutError', function *() {
       try {


### PR DESCRIPTION
maybe it's not necessary, but most of my use cases is `json` or `text`.
just too lazy to do `toString()` every time
